### PR TITLE
Fix redirection with OptionRedirect

### DIFF
--- a/lib/cached_routes/cached_redirect.rb
+++ b/lib/cached_routes/cached_redirect.rb
@@ -6,8 +6,7 @@ module CachedRoutes
     include ActionDispatch::Routing::Redirection
 
     def initialize(ad_redirect)
-      @path = case ad_redirect
-              when ActionDispatch::Routing::Redirect
+      @path = if ad_redirect.instance_of?(ActionDispatch::Routing::Redirect)
                 ad_redirect.path({}, nil)
               else
                 ad_redirect
@@ -15,7 +14,7 @@ module CachedRoutes
     end
 
     def to_action_dispatch_redirect
-      redirect(@path)
+      @path.is_a?(String) ? redirect(@path) : @path
     end
 
   end


### PR DESCRIPTION
`OptionRedirect` requires information from the actual request. This
patch prevents it from trying to generate the path too early.

The following cases should all be covered in Rails 3 and 4:

    get '/redir_path', to: redirect('/other')
    get '/redir_opt', to: redirect(path: '/other')
    get '/redir_block', to: redirect { |p, r| '/other' }

I'm not quite sure if this is anywhere close to a perfect solution. Without comprehensive testing I can only say that it seems to work and solves my problem. :) Please, have a look.